### PR TITLE
use translated string

### DIFF
--- a/CopyUrlInsteadOfShare/build.gradle.kts
+++ b/CopyUrlInsteadOfShare/build.gradle.kts
@@ -1,2 +1,2 @@
-version = "1.1.0"
+version = "1.1.1"
 description = "Replaces share message function with a copy url one"

--- a/CopyUrlInsteadOfShare/src/main/java/dev/nope/plugins/copyurlinsteadofshare/CopyUrlInsteadOfShareMessages.kt
+++ b/CopyUrlInsteadOfShare/src/main/java/dev/nope/plugins/copyurlinsteadofshare/CopyUrlInsteadOfShareMessages.kt
@@ -55,7 +55,7 @@ class CopyUrlInsteadOfShareMessages : Plugin() {
 
                     val copyMessageUrl =
                         TextView(ctx, null, 0, R.i.UiKit_Settings_Item_Icon).apply {
-                            text = context.getString(R.h.copy_link)
+                            text = ctx.getString(R.h.copy_link)
                             id = copyMessageUrlId
                             typeface = ResourcesCompat.getFont(ctx, Constants.Fonts.whitney_medium)
                             setCompoundDrawablesRelativeWithIntrinsicBounds(icon, null, null, null)

--- a/CopyUrlInsteadOfShare/src/main/java/dev/nope/plugins/copyurlinsteadofshare/CopyUrlInsteadOfShareMessages.kt
+++ b/CopyUrlInsteadOfShare/src/main/java/dev/nope/plugins/copyurlinsteadofshare/CopyUrlInsteadOfShareMessages.kt
@@ -55,7 +55,7 @@ class CopyUrlInsteadOfShareMessages : Plugin() {
 
                     val copyMessageUrl =
                         TextView(ctx, null, 0, R.i.UiKit_Settings_Item_Icon).apply {
-                            text = "Copy url"
+                            text = context.getString(R.h.copy_link)
                             id = copyMessageUrlId
                             typeface = ResourcesCompat.getFont(ctx, Constants.Fonts.whitney_medium)
                             setCompoundDrawablesRelativeWithIntrinsicBounds(icon, null, null, null)


### PR DESCRIPTION
instead of hardcoding "copy url" use the translated version